### PR TITLE
Add a JSON field "port" to reliably associate a device with a USB socket

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -100,6 +100,7 @@ class USBList(object):
           path = os.path.join(Temper.SYSPATH, entry.name)
           device = self._get_usb_device(path)
           if device is not None:
+            device['port'] = entry.name
             info[path] = device
     return info
 


### PR DESCRIPTION
While a device's "devnum" field changes each insertion/boot, making it hard for a program to identify a given device/sensor from the JSON output, a device's USB port-identifier reflects where it's plugged-in.