### PR TITLE
Support for TEMPer2_V3.7 1a86:e025

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ TEMPer     | 0c45:7401 | TEMPerF1.4      | I    |     | Metal
 TEMPer     | 413d:2107 | TEMPerGold_V3.1 | I    |     | Metal
 TEMPerHUM  | 413d:2107 | TEMPerX_V3.1    | I    | I   | White plastic
 TEMPer2    | 413d:2107 | TEMPerX_V3.3    | I,E  |     | White plastic
+TEMPer2    | 1a86:e025 | TEMPer2_V3.7    | I,E  |     | White plastic with red button
 TEMPer1F   | 413d:2107 | TEMPerX_V3.3    | E    |     | White plastic
 TEMPerX232 | 1a86:5523 | TEMPerX232_V2.0 | I,E  | I   | White plastic
 

--- a/temper.py
+++ b/temper.py
@@ -219,8 +219,9 @@ class USBRead(object):
 
     if info['firmware'][:12] == 'TEMPer2_V3.7':
       info['firmware'] = info['firmware'][:12]
-      #Bytes 5-8 is the device temp, devide by 4096
+      #Bytes 3-4 hold the device temp, divide by 100
       self._parse_bytes('internal temperature', 2, 100.0, bytes, info, self.verbose)
+      #Bytes 11-12 hold the external temp, divide by 100
       self._parse_bytes('external temperature', 10, 100.0, bytes, info, self.verbose)
       return info
 


### PR DESCRIPTION
Hello,

could you please merge support for TEMPer2_V3.7 1a86:e025 ?

I have initially started with urwen/temper, but it seems that this project is ahead. Creating a PR for your project. 

Thanks
Jirka

```
./temper.py --verbose
[sudo] password for jhladky: 
Firmware query: b'0186ff0100000000'
Firmware value: b'54454d506572325f56332e3720202020' TEMPer2_V3.7    
Data value: b'8080085f4e2000008001078b4e200000'
Converted value: b'085f'
Converted value: b'078b'
Bus 001 Dev 008 1a86:e025 TEMPer2_V3.7 21.43C 70.57F - 19.31C 66.76F -
```

```
./temper.py --json
[
    {
        "vendorid": 6790,
        "productid": 57381,
        "manufacturer": "",
        "product": "",
        "busnum": 1,
        "devnum": 8,
        "devices": [
            "hidraw6",
            "hidraw7"
        ],
        "firmware": "TEMPer2_V3.7",
        "hex_firmware": "54454d506572325f56332e3720202020",
        "hex_data": "8080085f4e2000008001078b4e200000",
        "internal temperature": 21.43,
        "external temperature": 19.31
    }
]
```