### PR TITLE
Add docker support for temper.py

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,55 @@
+Running temper as a service in docker container
+===============================================
+*The container provides the sensor metrics via web API*
+
+* Default port: `2600`
+* endpoint `/list`: List available USB devices in JSON format
+* endpoint `/metrics`: Send metrics from available temper devices in JSON format
+
+Running the service as a commandline
+------------------------------------
+```
+docker run --rm -it -p 2600:2600 temper/service:latest
+```
+
+
+Snippet of config in `docker-compose.yml`
+-----------------------------------------
+```
+---
+version: '3'
+
+services:
+  temper:
+    container_name: temper
+    hostname: temper
+    image: temper/service:latest
+    restart: always
+    ports:
+      - 2600:2600
+```
+
+Running the docker as a service using docker-compose config.
+```
+docker-compose up -d
+```
+
+Running the script `temper.py` from docker container
+----------------------------------------------------
+You can run `temper.py` as a docker container by overriding the entrypoint.
+```
+docker run --rm -it --entrypoint /opt/temper/bin/temper.py temper/service:latest --help
+usage: temper.py [-h] [-l] [--json] [--force VENDOR_ID:PRODUCT_ID] [--verbose]
+
+temper
+
+options:
+  -h, --help            show this help message and exit
+  -l, --list            List all USB devices
+  --json                Provide output as JSON
+  --force VENDOR_ID:PRODUCT_ID
+                        Force the use of the hex id; ignore other ids
+  --verbose             Output binary data from thermometer
+```
+
+Note: This dockerization effort was sponsored by Greenfly SAU LLC.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,5 +1,5 @@
-Running temper as a service in docker container
-===============================================
+Running `temper.py` as a service in docker container
+====================================================
 *The container provides the sensor metrics via web API*
 
 * Default port: `2610`
@@ -34,6 +34,18 @@ Running the docker as a service using docker-compose config.
 docker-compose up -d
 ```
 
+
+Checking the service from another terminal
+------------------------------------------
+```
+# List available USB devices (including temper devices)
+http localhost:2610/list | jq -C
+
+# Query temper metrics
+http localhost:2610/metrics | jq -C 
+```
+
+
 Running the script `temper.py` from docker container
 ----------------------------------------------------
 You can run `temper.py` as a docker container by overriding the entrypoint.
@@ -52,4 +64,4 @@ options:
   --verbose             Output binary data from thermometer
 ```
 
-Note: This dockerization effort was sponsored by Greenfly SAU LLC.
+**Note:** This dockerization effort was sponsored by Greenfly SAU LLC.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,14 +2,14 @@ Running temper as a service in docker container
 ===============================================
 *The container provides the sensor metrics via web API*
 
-* Default port: `2600`
+* Default port: `2610`
 * endpoint `/list`: List available USB devices in JSON format
 * endpoint `/metrics`: Send metrics from available temper devices in JSON format
 
 Running the service as a commandline
 ------------------------------------
 ```
-docker run --rm -it -p 2600:2600 temper/service:latest
+docker run --rm -it -p 2610:2610 temper/service:latest
 ```
 
 
@@ -26,7 +26,7 @@ services:
     image: temper/service:latest
     restart: always
     ports:
-      - 2600:2600
+      - 2610:2610
 ```
 
 Running the docker as a service using docker-compose config.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /opt/temper/bin
 COPY temper.py /opt/temper/bin
 COPY temper-service.py /opt/temper/bin
 
-EXPOSE 2600
+EXPOSE 2610
 
 WORKDIR /opt/temper/bin
 # This is used at commandline such as

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:22.04
+LABEL maintainer "tuan t. pham" <tuan@vt.edu>
+
+ENV PKGS="python3 python3-serial python3-pip" \
+    DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -yq update && apt-get dist-upgrade -yq \
+    && apt-get -yq install --no-install-recommends  ${PKGS} \
+    && pip3 install flask
+
+RUN apt-get autoremove -yq \
+    && apt-get autoclean \
+    && rm -fr /tmp/* /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/temper/bin
+
+COPY temper.py /opt/temper/bin
+COPY temper-service.py /opt/temper/bin
+
+EXPOSE 2600
+
+WORKDIR /opt/temper/bin
+# This is used at commandline such as
+# docker run --rm -it temper/service:latest -h
+ENTRYPOINT  ["/opt/temper/bin/temper-service.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+# A wrapper to build temper docker
+#
+# __author__: tuan t. pham
+
+DOCKER_NAME ?=temper
+DOCKER_SERVICE_NAME ?=temper/service
+DOCKER_TAG ?=latest
+
+
+docker.service:
+	docker build -t $(DOCKER_SERVICE_NAME):$(DOCKER_TAG) .
+#docker:
+#	docker build -t $(DOCKER_NAME):$(DOCKER_TAG) .

--- a/README.md
+++ b/README.md
@@ -305,3 +305,10 @@ $ ./temper.py --json
 ```
 
 Similar JSON output can be generated with the --list option.
+
+### Docker
+The docker image is built with `temper.py` and `temper-service.py`.
+The default `ENTRYPOINT` points to `temper-service.py` which runs as web
+service listening on port 2610. The web service responds to two endpoints:
+`/list` and `/metrics`. The result is in JSON format. See [`DOCKER.md`](./DOCKER.md)
+for more details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: '3'
+
+services:
+  temper:
+    container_name: temper
+    hostname: temper
+    image: temper/service:latest
+    restart: always
+    ports:
+      - 2600:2600

--- a/temper-service.py
+++ b/temper-service.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+
+from flask import Flask
+
+from temper import Temper
+
+# parsing config
+parser = argparse.ArgumentParser()
+parser.add_argument("-H", "--host", default="0.0.0.0", help="host to bind to, default: 0.0.0.0")
+parser.add_argument("-p", "--port", default=2600, help="port to listen to, default: 2600")
+parser.add_argument("-d", "--debug", default=False, help="debug mode, default: False")
+
+args = parser.parse_args()
+
+host = args.host
+port = int(args.port)
+debug = args.debug
+
+print(f"host = {host}")
+print(f"port = {port}")
+print(f"debug = {debug}")
+
+app = Flask("temper")
+t = Temper()
+
+@app.route('/list')
+def list():
+    result = json.dumps(t.usb_devices, indent=2, sort_keys=True)
+    return result
+
+@app.route('/Stats')
+def Stats():
+    result = json.dumps(t.read(), indent=2)
+    return result
+
+if __name__ == '__main__':
+    app.run(host=host, port=port, debug=debug)

--- a/temper-service.py
+++ b/temper-service.py
@@ -31,8 +31,8 @@ def list():
     result = json.dumps(t.usb_devices, indent=2, sort_keys=True)
     return result
 
-@app.route('/Stats')
-def Stats():
+@app.route('/metrics')
+def metrics():
     result = json.dumps(t.read(), indent=2)
     return result
 

--- a/temper-service.py
+++ b/temper-service.py
@@ -22,6 +22,9 @@ debug = args.debug
 print(f"host = {host}")
 print(f"port = {port}")
 print(f"debug = {debug}")
+print(f"Available endpoints:")
+print(f"/list = list available USB devices")
+print(f"/metrics = return availale metrics from temper USB devices")
 
 app = Flask("temper")
 t = Temper()

--- a/temper-service.py
+++ b/temper-service.py
@@ -10,7 +10,7 @@ from temper import Temper
 # parsing config
 parser = argparse.ArgumentParser()
 parser.add_argument("-H", "--host", default="0.0.0.0", help="host to bind to, default: 0.0.0.0")
-parser.add_argument("-p", "--port", default=2600, help="port to listen to, default: 2600")
+parser.add_argument("-p", "--port", default=2610, help="port to listen to, default: 2610")
 parser.add_argument("-d", "--debug", default=False, help="debug mode, default: False")
 
 args = parser.parse_args()


### PR DESCRIPTION
* Provide metrics from temper USB devices as a web service
* `temper.py` can be run as a docker container with custom `entrypoint`

The dockerization effort is sponsored by Greenfly SAU LLC.

cc: @greenmoss