### PR TITLE
Update info on DOCKER and fix docker-compose config

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -64,4 +64,6 @@ options:
   --verbose             Output binary data from thermometer
 ```
 
-**Note:** This dockerization effort was sponsored by Greenfly SAU LLC.
+**Note:** This dockerization effort was sponsored by [Greenfly SAU LLC.][0]
+
+[0]: https://greenfly.io

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,5 @@ services:
     image: temper/service:latest
     restart: always
     ports:
-      - 2600:2600
+      - 2610:2610
+    privileged: true


### PR DESCRIPTION
DOCKER.md:
    * Add URL to Greenfly

docker-compose.yml:
    * Fix port number to default 2610
    * Need to be privileged mode to read USB device

Signed-off-by: Tuan T. Pham <tuan@vt.edu>

CC: @eode 