### PR TITLE
Fix TEMPerHUM Firmware Selection Bug

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -230,8 +230,8 @@ class USBRead(object):
       #Bytes 11-12 hold the external temp, divide by 100
       self._parse_bytes('external temperature', 10, 100.0, bytes, info, self.verbose)
       return info
-    if info['firmware'][:16] == 'TEMPerHUM_V3.9':
-      info['firmware'] = info['firmware'][:16]
+    if info['firmware'][:14] == 'TEMPerHUM_V3.9':
+      info['firmware'] = info['firmware'][:14]
       #Bytes 3-4 hold the device temp, divide by 100
       self._parse_bytes('internal temperature', 2, 100.0, bytes, info, self.verbose)
       #Bytes 11-12 hold the external temp, divide by 100


### PR DESCRIPTION
This fixed a bug I was having with the TEMPerHUM where it would intermittently fail to fetch data.
It turns out the string "TEMPerHUM_V3.9" is only 14 characters long. The TEMPerHUM device has a total firmware string of "TEMPerHUM_V3.9  TEMPerHUM_V3.9".
This leads to the following results:
> With the old code
> `info["firmware"][:16] = "TEMPerHUM_V3.9  "`

> With my change
> `info["firmware"][:14] = "TEMPerHUM_V3.9"`
Thus it matches the expected behavior, otherwise the firmware version comparison will fail