### PR TITLE
Add support for TEMPerF1.2 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ In the following table "I" means the sensor is internal to the USB stick and
 
 Product     |    Id     |  Firmware        | Temp | Hum | Notes
 ------------|-----------|------------------|------|-----|---------------
+TEMPer      | 0c45:7401 | TEMPerF1.2       | I    |     | Metal
 TEMPer      | 0c45:7401 | TEMPerF1.4       | I    |     | Metal
 TEMPer      | 413d:2107 | TEMPerGold_V3.1  | I    |     | Metal
 TEMPer      | 1a86:e025 | TEMPerGold_V3.4  | I    |     | Metal

--- a/temper.py
+++ b/temper.py
@@ -200,7 +200,7 @@ class USBRead(object):
     info['hex_firmware'] = str(binascii.b2a_hex(firmware), 'latin-1')
     info['hex_data'] = str(binascii.b2a_hex(bytes), 'latin-1')
 
-    if info['firmware'][:10] in [ 'TEMPerF1.4', 'TEMPer1F1.' ]:
+    if info['firmware'][:10] in [ 'TEMPerF1.2', 'TEMPerF1.4', 'TEMPer1F1.' ]:
       info['firmware'] = info['firmware'][:10]
       self._parse_bytes('internal temperature', 2, 256.0, bytes, info)
       return info


### PR DESCRIPTION
I've got a metal TEMPer which lsusb identifies as 0c45:7401 "Microdia TEMPer Temperature Sensor" and it reports "TEMPerF1.2" as firmware. It works fine with temper-py, so here's a patch to enable it for everyone.
