### PR TITLE
Add support for TEMPer2_V4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ TEMPer2     | 413d:2107 | TEMPerX_V3.3     | I,E  |     | White plastic
 TEMPer2     | 1a86:e025 | TEMPer2_V3.7     | I,E  |     | White plastic with red button
 TEMPer2     | 1a86:e025 | TEMPer2_V3.9     | I,E  |     | White plastic with red button
 TEMPer2     | 1a86:e025 | TEMPer2_M12_V1.3 | I,E  |     | White plastic with red button
+TEMPer2     | 3553:a001 | TEMPer2_V4.1     | I,E  |     | White plastic with red button
 TEMPer1F    | 413d:2107 | TEMPerX_V3.3     | E    |     | White plastic
 TEMPerX232  | 1a86:5523 | TEMPerX232_V2.0  | I,E  | I   | White plastic
 TEMPer1V1.1 | 0c45:7401 | TEMPer1F1.1Per1F | E    |     | Metal

--- a/temper.py
+++ b/temper.py
@@ -239,6 +239,11 @@ class USBRead(object):
       #Bytes 5-6 hold the device humidity, divide by 100
       self._parse_bytes('internal humidity', 4, 100.0, bytes, info)
       return info
+    if info['firmware'][:12] == 'TEMPer2_V4.1':
+      info['firmware'] = info['firmware'][:12]
+      self._parse_bytes('internal temperature', 2, 100.0, bytes, info)
+      self._parse_bytes('external temperature', 10, 100.0, bytes, info, self.verbose)
+      return info
     info['error'] = 'Unknown firmware %s: %s' % (info['firmware'],
                                                  binascii.hexlify(bytes))
     return info
@@ -310,6 +315,7 @@ class Temper(object):
   def _is_known_id(self, vendorid, productid):
     '''Returns True if the vendorid and product id are valid.
     '''
+
     if self.forced_vendor_id is not None and \
        self.forced_product_id is not None:
       if self.forced_vendor_id == vendorid and \
@@ -324,6 +330,8 @@ class Temper(object):
     if vendorid == 0x1a86 and productid == 0x5523:
       return True
     if vendorid == 0x1a86 and productid == 0xe025:
+      return True
+    if vendorid == 0x3553 and productid == 0xa001:
       return True
 
     # The id is not known to this program.


### PR DESCRIPTION
I bought a device that reports itself as `TEMPer2_V4.1`. This PR adds support for that device.