### PR TITLE
add external humidity from hs10 sensor

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -278,10 +278,11 @@ class USBRead(object):
     if m is not None:
       info['internal temperature'] = float(m.group(1))
       info['internal humidity'] = float(m.group(2))
-    m = re.search(r'Temp-Outer:([0-9.]*)', reply)
+    m = re.search(r'Temp-Outer:([0-9.]*).*?, ?([0-9.]*)', reply)
     if m is not None:
       try:
         info['external temperature'] = float(m.group(1))
+        info['external humidity'] = float(m.group(2))
       except:
         pass
     return info


### PR DESCRIPTION
get external humidity from hs10 sensor with TEMPerX232 https://pcsensor.com/product-details?product_id=797

raw reply lines look like
Temp-Outer:27.31 [C],53.29 [%RH]<Temp-Inner:34.82 [C],35.73 [%RH]<. 

need the non greedy regex .*? between temp and humidity for external otherwise it will grab the internal humidity as external