### PR TITLE
Add support for TEMPer1F_H1V1.5F

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ TEMPer      | 1a86:e025 | TEMPerGold_V3.3  | I    |     | Metal
 TEMPer      | 1a86:e025 | TEMPerGold_V3.4  | I    |     | Metal
 TEMPerHUM   | 413d:2107 | TEMPerX_V3.1     | I    | I   | White plastic
 TEMPerHUM   | 1a86:e025 | TEMPerHUM_3.9    |      | I   | White plastic with blue button
+TEMPerHUM   | 0c45:7402 | TEMPer1F_H1V1.5F | I    | I   | White plastic with blue button
 TEMPer2     | 413d:2107 | TEMPerX_V3.3     | I,E  |     | White plastic
 TEMPer2     | 1a86:e025 | TEMPer2_V3.7     | I,E  |     | White plastic with red button
 TEMPer2     | 1a86:e025 | TEMPer2_V3.9     | I,E  |     | White plastic with red button

--- a/temper.py
+++ b/temper.py
@@ -239,6 +239,23 @@ class USBRead(object):
       #Bytes 5-6 hold the device humidity, divide by 100
       self._parse_bytes('internal humidity', 4, 100.0, bytes, info)
       return info
+    if info['firmware'][:16] == 'TEMPer1F_H1V1.5F':
+      info['firmware'] = info['firmware'][:16]
+      self._parse_bytes('internal temperature', 2, 1, bytes, info, verbose=self.verbose)
+      self._parse_bytes('internal humidity', 4, 1, bytes, info, verbose=self.verbose)
+      # The values are not aligned to the byte boundary, so shift them. And
+      # then apply the equations from the SHT20 data sheet.
+      t = int(info['internal temperature']) << 2
+      if self.verbose:
+        print(f'Raw temperature: {t}')
+      t = -46.85 + 175.72 * t / 65536
+      info['internal temperature'] = t
+      h = int(info['internal humidity']) << 4
+      if self.verbose:
+        print(f'Raw humidity: {h}')
+      h = -6 + 125.0 * h / 65536
+      info['internal humidity'] = h
+      return info
     info['error'] = 'Unknown firmware %s: %s' % (info['firmware'],
                                                  binascii.hexlify(bytes))
     return info
@@ -317,7 +334,7 @@ class Temper(object):
         return True
       return False
 
-    if vendorid == 0x0c45 and productid == 0x7401:
+    if vendorid == 0x0c45 and (productid == 0x7401 or productid == 0x7402):
       return True
     if vendorid == 0x413d and productid == 0x2107:
       return True


### PR DESCRIPTION
Firmware TEMPer1F_H1V1.5F (id 0c45:7402) seems to be using a different temperature sensor (SHT20). This change adds support for this sensor/firmware combination.