### PR TITLE
One likely fix, 2 cosmetic fixes, udev-rules-file

### DIFF
--- a/etc--udev--rules.d--24-TEMPer.rules
+++ b/etc--udev--rules.d--24-TEMPer.rules
@@ -1,0 +1,6 @@
+ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7401", GROUP="plugdev", MODE="660"
+ATTRS{idVendor}=="0c45", ATTRS{idProduct}=="7402", GROUP="plugdev", MODE="660"
+ATTRS{idVendor}=="413d", ATTRS{idProduct}=="2107", GROUP="plugdev", MODE="660"
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", GROUP="plugdev", MODE="660"
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e025", GROUP="plugdev", MODE="660"
+ATTRS{idVendor}=="3553", ATTRS{idProduct}=="a001", GROUP="plugdev", MODE="660"

--- a/temper.py
+++ b/temper.py
@@ -303,7 +303,7 @@ class USBRead(object):
 
     info = dict()
     info['firmware'] = firmware
-    m = re.search(r'Temp-Inner:([0-9.]*).*, ?([0-9.]*)', reply)
+    m = re.search(r'Temp-Inner:([0-9.]*).*?, ?([0-9.]*)', reply)
     if m is not None:
       info['internal temperature'] = float(m.group(1))
       info['internal humidity'] = float(m.group(2))
@@ -338,7 +338,7 @@ class Temper(object):
     self.verbose = verbose
 
   def _is_known_id(self, vendorid, productid):
-    '''Returns True if the vendorid and product id are valid.
+    '''Returns True if the vendorid and productid are valid.
     '''
 
     if self.forced_vendor_id is not None and \
@@ -479,8 +479,8 @@ class Temper(object):
       except:
         print('Cannot parse hexadecimal id: %s' % args.force)
         return 1
-      self.forced_vendor_id = vendor_id;
-      self.forced_product_id = product_id;
+      self.forced_vendor_id = vendor_id
+      self.forced_product_id = product_id
 
     # By default, output the temperature and humidity for all known sensors.
     results = self.read(args.verbose)


### PR DESCRIPTION
This PR adds the following:

"etc--udev--rules.d--24-TEMPer.rules"
This file can be copied to /etc/udev/rules.d/24-TEMPer.rules, then any of the
supported thermometers will have their device-entries (`hidraw*` or `tty*`) 
be read- and writeable by all users of group "plugdev" - allowing to use
temper.py without sudo.

In temper.py there is one change in a regular expression.
A couple lines down from that there was a "recent" change in
a similar regular expression, and it makes sense for me, that 
the two regular expressions should be structurally equal.
But then again, I do not own one of these devices, so I cannot
test them myself.
The removed semicolons ";" are purely cosmetic, and so is
the one change in a function's comment.

Take it, leave it, or cherrypick it...  :-)