### PR TITLE
Add support for the TEMPerHUM_V3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ TEMPer      | 1a86:e025 | TEMPerGold_V3.4  | I    |     | Metal
 TEMPer      | 3553:a001 | TEMPerGold_V3.5  | I    |     | Metal
 TEMPerHUM   | 413d:2107 | TEMPerX_V3.1     | I    | I   | White plastic
 TEMPerHUM   | 1a86:e025 | TEMPerHUM_3.9    |      | I   | White plastic with blue button
+TEMPerHUM   | 1a86:e025 | TEMPerHUM_V3.8   | I    | I   | White plastic with blue button
 TEMPerHUM   | 0c45:7402 | TEMPer1F_H1V1.5F | I    | I   | White plastic with blue button
 TEMPer2     | 413d:2107 | TEMPerX_V3.3     | I,E  |     | White plastic
 TEMPer2     | 1a86:e025 | TEMPer2_V3.7     | I,E  |     | White plastic with red button

--- a/temper.py
+++ b/temper.py
@@ -230,7 +230,7 @@ class USBRead(object):
       #Bytes 11-12 hold the external temp, divide by 100
       self._parse_bytes('external temperature', 10, 100.0, bytes, info, self.verbose)
       return info
-    if info['firmware'][:14] == 'TEMPerHUM_V3.9':
+    if info['firmware'][:14] in [ 'TEMPerHUM_V3.9', 'TEMPerHUM_V3.8' ]:
       info['firmware'] = info['firmware'][:14]
       #Bytes 3-4 hold the device temp, divide by 100
       self._parse_bytes('internal temperature', 2, 100.0, bytes, info, self.verbose)


### PR DESCRIPTION
This will add support for a USB sensoe I have that reports itself as a TEMPerHUM_V3.8. I've been running this change reliably for quite a while and decided I should upstream it.

`#2025-11-01-21:24:34#0#root@jarvis:/usr/local/src/temper2 ☉ ./temper.py --verbose
Firmware query: b'0186ff0100000000'
Firmware value: b'54454d50657248554d5f56332e382020' TEMPerHUM_V3.8  
Data value: b'8020090111930000'
Converted value: b'0901'
Bus 001 Dev 002 1a86:e025 TEMPerHUM_V3.8 23.05C 73.49F 44% - - -
#2025-11-01-21:24:50#0#root@jarvis:/usr/local/src/temper2 ☉ git reset --hard HEAD
HEAD is now at 60889bf Merge pull request #40 from damg22/master
#2025-11-01-21:24:54#0#root@jarvis:/usr/local/src/temper2 ☉ ./temper.py --verbose
Firmware query: b'0186ff0100000000'
Firmware value: b'54454d50657248554d5f56332e382020' TEMPerHUM_V3.8  
Data value: b'802008ff11af0000'
Bus 001 Dev 002 1a86:e025 TEMPerHUM_V3.8 Error: Unknown firmware TEMPerHUM_V3.8: b'802008ff11af0000'
#2025-11-01-21:24:56#0#root@jarvis:/usr/local/src/temper2 ☉ 
`