### PR TITLE
make 'import serial' dependency sometimes optional

### DIFF
--- a/temper.py
+++ b/temper.py
@@ -32,10 +32,9 @@ import sys
 
 # Non-standard modules
 try:
-  import serial
+  import serial as _
 except ImportError:
-  print('Cannot import "serial". Please sudo apt-get install python3-serial')
-  sys.exit(1)
+  print('WARNING: Cannot import "serial" for tty devices. Only hidraw devices will work. Please sudo apt-get install python3-serial', file=sys.stderr)
 
 
 class USBList(object):
@@ -279,6 +278,7 @@ class USBRead(object):
     A dictionary of device info (like that returned by USBList) combined with
     temperature and humidity info is returned.
     '''
+    import serial
 
     path = os.path.join('/dev', device)
     s = serial.Serial(path, 9600)


### PR DESCRIPTION
I don't have a tty device, only a hidraw device. I imagine many people only have 1 device they want to support, so the tty-specific dependency doesn't apply to some people (including me).

This PR prints a warning on failure to `import serial` instead of exiting with an error, and the warning explains what's going to work and not work.

Here's what it looks like with a hidraw device without and with the serial system dependency:

```console
josh@nixos:~/dev/temper$ ./temper.py 
WARNING: Cannot import "serial" for tty devices. Only hidraw devices will work. Please sudo apt-get install python3-serial
Bus 003 Dev 080 3553:a001 TEMPer1F_V4.1 23.43C 74.17F - - - -
josh@nixos:~/dev/temper$ nix-run -p python312Packages.pyserial -- ./temper.py 
Bus 003 Dev 080 3553:a001 TEMPer1F_V4.1 23.43C 74.17F - - - -
```

for a tty device, the situation would look something like this: (I tested this by hacking the code to artificially hit this codepath because i don't have a tty device.)

```console
josh@nixos:~/dev/temper$ ./temper.py 
WARNING: Cannot import "serial" for tty devices. Only hidraw devices will work. Please sudo apt-get install python3-serial
Traceback (most recent call last):
  File "/home/josh/dev/temper/./temper.py", line 497, in <module>
    main()
  File "/home/josh/dev/temper/./temper.py", line 494, in main
    sys.exit(temper.main())
             ^^^^^^^^^^^^^
  File "/home/josh/dev/temper/./temper.py", line 487, in main
    results = self.read(args.verbose)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/josh/dev/temper/./temper.py", line 404, in read
    results.append({ **info, **usbread.read() })
                               ^^^^^^^^^^^^^^
  File "/home/josh/dev/temper/./temper.py", line 328, in read
    return self._read_serial(self.device)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/josh/dev/temper/./temper.py", line 281, in _read_serial
    import serial
ModuleNotFoundError: No module named 'serial'
```